### PR TITLE
Critical Bugfix: TypeError: unhashable type: 'list'.  

### DIFF
--- a/src/analyzer/algorithms.py
+++ b/src/analyzer/algorithms.py
@@ -175,7 +175,7 @@ def run_selected_algorithm(timeseries):
         raise Incomplete()
 
     # Get rid of boring series
-    if len(set(timeseries[-MAX_TOLERABLE_BOREDOM:])) == 1:
+    if len(set(item[1] for item in timeseries[-MAX_TOLERABLE_BOREDOM:])) == 1:
         raise Boring()
 
     try:


### PR DESCRIPTION
Resolution: Include only the data points from timeseries in the set.  Discovered while testing in algorithms_tests branch.

Relevant error, fixed with this changeset:

```
Traceback (most recent call last):
  File "/Users/oxtopus/Desktop/skyline/lib/python2.7/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/Users/oxtopus/Desktop/skyline/src/analyzer/algorithms_test.py", line 60, in test_run_selected_algorithm
    result, ensemble, tail_avg = algorithms.run_selected_algorithm(timeseries)
  File "/Users/oxtopus/Desktop/skyline/src/analyzer/algorithms.py", line 186, in run_selected_algorithm
    if len(set(timeseries[-MAX_TOLERABLE_BOREDOM:])) == 1:
TypeError: unhashable type: 'list'
```

Basically a side effect of creating a set from a list of lists (i.e. `set([[1,2]])`).  If `timeseries` were a list of tuples, it would work, however.
