### PR TITLE
Remove sudo in init script

### DIFF
--- a/src/horizon/listen.py
+++ b/src/horizon/listen.py
@@ -17,10 +17,6 @@ class Listen(Process):
     """
     def __init__(self, port, queue, parent_pid, type="pickle"):
         super(Listen, self).__init__()
-        try:
-            self.ip = settings.HORIZON_IP
-        except NameError:
-            self.ip = '127.0.0.1'
         self.port = port
         self.q = queue
         self.daemon = True
@@ -68,7 +64,7 @@ class Listen(Process):
                 # Set up the TCP listening socket 
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
-                s.bind((self.ip, self.port))
+                s.bind((socket.gethostname(), self.port))
                 s.setblocking(1)
                 s.listen(5)
                 logger.info('listening over tcp for pickles on %s' % self.port)
@@ -115,7 +111,7 @@ class Listen(Process):
         while 1:
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.bind((self.ip, self.port))
+                s.bind((socket.gethostname(), self.port))
                 logger.info('listening over udp for messagepack on %s' % self.port)
 
                 chunk = []

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -96,9 +96,6 @@ Horizon settings
 # queue.
 WORKER_PROCESSES = 2
 
-# The IP address for Horizon to listen on
-HORIZON_IP = '127.0.0.1'
-
 # This is the port that listens for Graphite pickles over TCP, sent by Graphite's
 # carbon-relay agent.
 PICKLE_PORT = 2024


### PR DESCRIPTION
The init scripts for horizon and analyzer use sudo when killing the process.  This prevents the process from running as a non-root user non-interactively.  As far as I can tell the stop still works fine without it.
