### PR TITLE
Allow start/stop scripts to be run from anywhere

### DIFF
--- a/bin/analyzer.d
+++ b/bin/analyzer.d
@@ -2,11 +2,12 @@
 #
 # This is used to start/stop the analyzer
 
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 RETVAL=0
 
 start () {
-    rm ../src/analyzer/*.pyc
-    /usr/bin/env python ../src/analyzer/analyzer-agent.py start
+    rm -f $BASEDIR/src/analyzer/*.pyc
+    /usr/bin/env python $BASEDIR/src/analyzer/analyzer-agent.py start
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "started analyzer-agent"
@@ -19,7 +20,7 @@ start () {
 stop () {
     # TODO: write a real kill script
     ps aux | grep 'analyzer-agent.py start' | grep -v grep | awk '{print $2 }' | xargs sudo kill -9
-    /usr/bin/env python ../src/analyzer/analyzer-agent.py stop
+    /usr/bin/env python $BASEDIR/src/analyzer/analyzer-agent.py stop
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "stopped analyzer-agent"

--- a/bin/horizon.d
+++ b/bin/horizon.d
@@ -2,11 +2,12 @@
 #
 # This is used to start/stop horizon 
 
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 RETVAL=0
 
 start () {
-    rm ../src/horizon/*.pyc
-    /usr/bin/env python ../src/horizon/horizon-agent.py start
+    rm $BASEDIR/src/horizon/*.pyc
+    /usr/bin/env python $BASEDIR/src/horizon/horizon-agent.py start
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "started horizon-agent"
@@ -19,7 +20,7 @@ start () {
 stop () {
     # TODO: write a real kill script
     ps aux | grep 'horizon-agent.py start' | grep -v grep | awk '{print $2 }' | xargs sudo kill -9
-    /usr/bin/env python ../src/horizon/horizon-agent.py stop
+    /usr/bin/env python $BASEDIR/src/horizon/horizon-agent.py stop
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "stopped horizon-agent"

--- a/bin/webapp.d
+++ b/bin/webapp.d
@@ -2,11 +2,12 @@
 #
 # This is used to start/stop webapp 
 
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 RETVAL=0
 
 start () {
-    rm ../src/webapp/*.pyc
-    /usr/bin/env python ../src/webapp/webapp.py start
+    rm -f $BASEDIR/src/webapp/*.pyc
+    /usr/bin/env python $BASEDIR/src/webapp/webapp.py start
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "started webapp"
@@ -17,7 +18,7 @@ start () {
 }
 
 stop () {
-    /usr/bin/env python ../src/webapp/webapp.py stop
+    /usr/bin/env python $BASEDIR/src/webapp/webapp.py stop
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "stopped webapp"
@@ -28,8 +29,8 @@ stop () {
 }
 
 restart () {
-    rm ../src/webapp/*.pyc
-    /usr/bin/env python ../src/webapp/webapp.py restart
+    rm -f $BASEDIR/src/webapp/*.pyc
+    /usr/bin/env python $BASEDIR/src/webapp/webapp.py restart
         RETVAL=$?
         if [[ $RETVAL -eq 0 ]]; then
             echo "restarted webapp"


### PR DESCRIPTION
Also add -f to rm in start/stop scripts to suppress no such file warnings.

BASEDIR calculated from this Stack Overflow: http://stackoverflow.com/a/246128
