### PR TITLE
Abstracting alerters and adding HipChat and PagerDuty

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,11 +79,13 @@ Once you get real data flowing through your system, the Analyzer will be able
 start analyzing for anomalies!
 
 ### Alerts
-Skyline can alert you via email! In your settings.py, add any alerts you want
-to the ALERTS list, according to the schema `(metric keyword, recipient,
-expiration seconds)`. For every anomalous metric, Skyline will search for the
-given keyword and alert the proper recipient. To prevent alert fatigue, Skyline
-will only alert once every <expiration seconds> for any given metric.
+Skyline can alert you! In your settings.py, add any alerts you want to the ALERTS
+list, according to the schema `(metric keyword, strategy, expiration seconds)` where
+`strategy` is one of `smtp`, `hipchat`, or `pagerduty`. You can also add your own
+alerting strategies. For every anomalous metric, Skyline will search for the given
+keyword and trigger the corresponding alert(s). To prevent alert fatigue, Skyline
+will only alert once every <expiration seconds> for any given metric/strategy
+combination.
 
 ### How do you actually detect anomalies?
 An ensemble of algorithms vote. Majority rules. Batteries __kind of__ included.

--- a/src/analyzer/alerters.py
+++ b/src/analyzer/alerters.py
@@ -1,0 +1,63 @@
+from email.MIMEMultipart import MIMEMultipart
+from email.MIMEText import MIMEText
+from email.MIMEImage import MIMEImage
+from smtplib import SMTP
+import alerters, settings
+
+
+"""
+Create any alerter you want here. The function will be invoked from trigger_alert.
+Two arguments will be passed, both of them tuples: alert and metric.
+
+alert: the tuple specified in your settings:
+    alert[0]: The matched substring of the anomalous metric
+    alert[1]: the name of the strategy being used to alert
+    alert[2]: The timeout of the alert that was triggered
+metric: information about the anomaly itself
+    metric[0]: the anomalous value
+    metric[1]: The full name of the anomalous metric
+"""
+
+def alert_smtp(alert, metric):
+
+    # For backwards compatibility
+    if '@' in alert[1]:
+        sender = settings.ALERT_SENDER
+        recipient = alert[1]
+    else:
+        sender = settings.SMTP_OPTS['sender']
+        recipient = settings.SMTP_OPTS['recipients'][alert[0]]
+
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = '[skyline alert] ' + metric[1]
+    msg['From'] = sender
+    msg['To'] = recipient
+    link = '%s/render/?width=588&height=308&target=%s' % (settings.GRAPHITE_HOST, metric[1])
+    body = 'Anomalous value: %s <br> Next alert in: %s seconds <a href="%s"><img src="%s"/></a>' % (metric[0], alert[2], link, link)
+    msg.attach(MIMEText(body, 'html'))
+    s = SMTP('127.0.0.1')
+    s.sendmail(sender, recipient, msg.as_string())
+    s.quit()
+
+def alert_pagerduty(alert, metric):
+    import pygerduty
+    pager = pygerduty.PagerDuty(settings.PAGERDUTY_OPTS['subdomain'], settings.PAGERDUTY_OPTS['auth_token'])
+    pager.trigger_incident(settings.PAGERDUTY_OPTS['key'], "Anomalous metric: %s (value: %s)" % (metric[1], metric[0]))
+
+def alert_hipchat(alert, metric):
+    import hipchat
+    hipster = hipchat.HipChat(token = settings.HIPCHAT_OPTS['auth_token'])
+    rooms = settings.HIPCHAT_OPTS['rooms'][alert[0]]
+    link = '%s/render/?width=588&height=308&target=%s' % (settings.GRAPHITE_HOST, metric[1])
+
+    for room in rooms:
+        hipster.method('rooms/message', method='POST', parameters={'room_id': room, 'from': 'Skyline', 'color': settings.HIPCHAT_OPTS['color'], 'message': 'Anomaly: <a href="%s">%s</a> : %s' % (link, metric[1], metric[0])})
+
+def trigger_alert(alert, metric):
+
+    if '@' in alert[1]:
+        strategy = 'alert_smtp'
+    else:
+        strategy = 'alert_' + alert[1]
+
+    getattr(alerters, strategy)(alert, metric)

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -91,21 +91,52 @@ ALGORITHMS = [
 # classified as anomalous.
 CONSENSUS = 7
 
-# This enables email alerting.
+# This enables alerting.
 ENABLE_ALERTS = True
 
-# This specifies the sender of the email alerts.
-ALERT_SENDER = "skyline-alerts@etsy.com"
-
-# This is the config for which metrics to alert on and who to send them to.
+# This is the config for which metrics to alert on and which strategy to use for each.
 # Alerts will not fire twice within EXPIRATION_TIME, even if they trigger again.
 # Schema: (
-#          ("metric1", "recipient1", EXPIRATION_TIME),
-#          ("metric2", "recipient2", EXPIRATION_TIME),
+#          ("metric1", "smtp", EXPIRATION_TIME),
+#          ("metric2", "pagerduty", EXPIRATION_TIME),
+#          ("metric3", "hipchat", EXPIRATION_TIME),
 #         )
 ALERTS = (
-            ("skyline", "abe@etsy.com", 1800),
-         )
+			("skyline", "smtp", 1800),
+		 )
+
+# Each alert module requires additional information.
+SMTP_OPTS = {
+    # This specifies the sender of email alerts.
+    "sender": "skyline-alerts@etsy.com",
+    # recipients is a dictionary mapping metric names
+    # (exactly matching those listed in ALERTS) to e-mail addresses
+    "recipients": {
+        "skyline": "abe@etsy.com",
+    },
+}
+
+# HipChat alerts require python-simple-hipchat
+HIPCHAT_OPTS = {
+    "auth_token": "pagerduty_auth_token",
+    # list of hipchat room_ids to notify about each anomaly
+    # (similar to SMTP_OPTS['recipients'])
+    "rooms":{
+        "skyline": (12345,),
+    }
+    # Background color of hipchat messages
+    # (One of "yellow", "red", "green", "purple", "gray", or "random".)
+    "color": "purple",
+}
+
+# PagerDuty alerts require pygerduty
+PAGERDUTY_OPTS = {
+    # Your pagerduty subdomain and auth token
+    "subdomain": "example",
+    "auth_token": "your_pagerduty_auth_token",
+    # Service API key (shown on the detail page of a "Generic API" service)
+    "key": "your_pagerduty_service_api_key",
+}
 
 
 """


### PR DESCRIPTION
We had been trying for a while to figure out how be notified about anomalies, since we don't have someone monitoring a wall board 24/7. When we noticed you added alerting we were really excited but felt e-mail was a little bit impractical for our purposes.

To address that I've abstracted the alerting code, trying to follow a similar pattern to your algorithms, and added alerts that will send messages to HipChat and/or trigger incidents in Pagerduty. Additional alerts can be added with minimal effort.

The alert settings schema has changed a bit, but the changes are backwards compatible with settings.py from your previous commit. If you feel that's not necessary then this can be cleaned up a bit.

I'm interested to hear your feedback on these changes. I'm happy to refactor if you'd prefer it be done differently.
