### PR TITLE
Added python-simple-hipchat to requirements.txt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,8 @@ list, according to the schema `(metric keyword, strategy, expiration seconds)` w
 alerting strategies. For every anomalous metric, Skyline will search for the given
 keyword and trigger the corresponding alert(s). To prevent alert fatigue, Skyline
 will only alert once every <expiration seconds> for any given metric/strategy
-combination.
+combination. To enable Hipchat integration, uncomment the python-simple-hipchat
+line in the requirements.txt file.
 
 ### How do you actually detect anomalies?
 An ensemble of algorithms vote. Majority rules. Batteries __kind of__ included.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask==0.9
 simplejson==2.0.9
 unittest2
 mock
+#python-simple-hipchat


### PR DESCRIPTION
I struggled a little bit to get skyline to send metrics to hipchat until I found out that I should install the python-simple-hipchat package. So I added it to the requirements and created a comment in README file, so other people don't have the same difficulty.
