### PR TITLE
Allow for HTTPS Graphite servers.

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from Queue import Empty
 from redis import StrictRedis
 from time import time, sleep
@@ -47,7 +48,8 @@ class Analyzer(Thread):
     def send_graphite_metric(self, name, value):
         if settings.GRAPHITE_HOST != '':
             sock = socket.socket()
-            sock.connect((settings.GRAPHITE_HOST.replace('http://', ''), settings.CARBON_PORT))
+            graphite_host = re.sub('http[s]?://', '', settings.GRAPHITE_HOST)
+            sock.connect((graphite_host, settings.CARBON_PORT))
             sock.sendall('%s %s %i\n' % (name, value, time()))
             sock.close()
             return True

--- a/src/horizon/worker.py
+++ b/src/horizon/worker.py
@@ -48,7 +48,8 @@ class Worker(Process):
     def send_graphite_metric(self, name, value):
         if settings.GRAPHITE_HOST != '':
             sock = socket.socket()
-            sock.connect((settings.GRAPHITE_HOST.replace('http://', ''), settings.CARBON_PORT))
+            graphite_host = re.sub('http[s]?://', '', settings.GRAPHITE_HOST)
+            sock.connect((graphite_host, settings.CARBON_PORT))
             sock.sendall('%s %s %i\n' % (name, value, time()))
             sock.close()
             return True


### PR DESCRIPTION
If a settings.GRAPHITE_HOST contains an HTTPS Graphite server, this replacement fails. Using a regular expression to allow for both http and https URI protocols.

In the future, perhaps this interpretation should live in settings, rather than in each place in the code?
