### PR TITLE
Add ability to embed graphite graphs in emails

### DIFF
--- a/src/analyzer/alerters.py
+++ b/src/analyzer/alerters.py
@@ -5,6 +5,8 @@ from smtplib import SMTP
 import alerters
 import settings
 
+import urllib2
+
 
 """
 Create any alerter you want here. The function will be invoked from trigger_alert.
@@ -34,14 +36,36 @@ def alert_smtp(alert, metric):
     if type(recipients) is str:
         recipients = [recipients]
 
+    link = '%s/render/?width=588&height=308&target=%s' % (settings.GRAPHITE_HOST, metric[1])
+    content_id = metric[1]
+    image_data = None
+    if settings.SMTP_OPTS.get('embed-images'):
+        try:
+            image_data = urllib2.urlopen(link).read()
+        except urllib2.URLError:
+            image_data = None
+
+    # If we failed to get the image or if it was explicitly disabled,
+    # use the image URL instead of the content.
+    if image_data is None:
+        img_tag = '<img src="%s"/>' % link
+    else:
+        img_tag = '<img src="cid:%s"/>' % content_id
+
+    body = 'Anomalous value: %s <br> Next alert in: %s seconds <br> <a href="%s">%s</a>' % (metric[0], alert[2], link, img_tag)
+
     for recipient in recipients:
         msg = MIMEMultipart('alternative')
         msg['Subject'] = '[skyline alert] ' + metric[1]
         msg['From'] = sender
         msg['To'] = recipient
-        link = '%s/render/?width=588&height=308&target=%s' % (settings.GRAPHITE_HOST, metric[1])
-        body = 'Anomalous value: %s <br> Next alert in: %s seconds <a href="%s"><img src="%s"/></a>' % (metric[0], alert[2], link, link)
+
         msg.attach(MIMEText(body, 'html'))
+        if image_data is not None:
+            msg_attachment = MIMEImage(image_data)
+            msg_attachment.add_header('Content-ID', '<%s>' % content_id)
+            msg.attach(msg_attachment)
+
         s = SMTP('127.0.0.1')
         s.sendmail(sender, recipient, msg.as_string())
         s.quit()

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -130,6 +130,7 @@ SMTP_OPTS = {
     "recipients": {
         "skyline": ["abe@etsy.com", "you@yourcompany.com"],
     },
+    "embed-images": False
 }
 
 # HipChat alerts require python-simple-hipchat


### PR DESCRIPTION
## Change

This adds a new config option to SMTP_OPTS, 'embed-images' which is a bool. When true, it will download the image content from the graphite host and embed it in the alert email. If fetching the content fails or this setting is false, the old behavior is used.
## Rationale

Our organization uses GMail (apps for your domain), which attempts to fetch and cache the images from our graphite host, which is on our company intranet. This results in every graph being a broken image. Additionally, this removes the requirement that recipients be on our company VPN in order to see the graphs (exceptionally helpful on mobile devices).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/etsy/skyline/76)

<!-- Reviewable:end -->
