### PR TITLE
Load in algorithms from external module

### DIFF
--- a/src/analyzer/algorithms.py
+++ b/src/analyzer/algorithms.py
@@ -4,11 +4,14 @@ import scipy
 import statsmodels.api as sm
 import traceback
 import logging
+import imp
+import sys
 from time import time
 from msgpack import unpackb, packb
 from redis import StrictRedis
 
 from settings import (
+    CUSTOM_ALGORITHM_MODULE,
     ALGORITHMS,
     CONSENSUS,
     FULL_DURATION,
@@ -21,6 +24,16 @@ from settings import (
 )
 
 from algorithm_exceptions import *
+
+# If you have a custom module for algorithms, load it here and inject into globals
+if CUSTOM_ALGORITHM_MODULE:
+    try:
+        m = imp.load_module(CUSTOM_ALGORITHM_MODULE, *imp.find_module(CUSTOM_ALGORITHM_MODULE))
+        sys.modules['tmp_algorithms'] = m
+        from tmp_algorithms import *
+    except:
+        pass
+
 
 logger = logging.getLogger("AnalyzerLog")
 redis_conn = StrictRedis(unix_socket_path=REDIS_SOCKET_PATH)

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -99,6 +99,10 @@ ALGORITHMS = [
     'ks_test',
 ]
 
+# This allows a custom module to be loaded into the global namespace of the algorithm.py
+# file. Use this to bring in function from outside of skyline
+CUSTOM_ALGORITHM_MODULE = ''
+
 # This is the number of algorithms that must return True before a metric is
 # classified as anomalous.
 CONSENSUS = 6


### PR DESCRIPTION
This means you can have some business critical logic in a separate module, while still being able to maintain a public fork of skyline.

I have some functionality to define custom_analysers too (have specific algorithms to run on specific metrics) which I can make a pull request for too. It is all defined in the settings file, but I'm not sure if that's the direction that you want Skyline to go in.
