### PR TITLE
Add skyline.analyzer.total_anomalies to graphite

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -221,6 +221,7 @@ class Analyzer(Thread):
             # Log to Graphite
             self.send_graphite_metric('skyline.analyzer.run_time', '%.2f' % (time() - now))
             self.send_graphite_metric('skyline.analyzer.total_analyzed', '%.2f' % (len(unique_metrics) - sum(exceptions.values())))
+            self.send_graphite_metric('skyline.analyzer.total_anomalies', '%.2f' % len(self.anomalous_metrics))
 
             # Check canary metric
             raw_series = self.redis_conn.get(settings.FULL_NAMESPACE + settings.CANARY_METRIC)


### PR DESCRIPTION
This seems to be a very simple missing metric that is calculated and not going
to graphite.  This metric is an interesting metric to monitor and analyse as a
timeseries in itself and it becoming anomalous would probably be a bad thing.
Modified:
src/analyzer/analyzer.py
