### PR TITLE
Fix analyzer worker metric assignment

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -63,8 +63,8 @@ class Analyzer(Thread):
         if i == settings.ANALYZER_PROCESSES:
             assigned_max = len(unique_metrics)
         else:
-            assigned_max = i * keys_per_processor
-        assigned_min = assigned_max - keys_per_processor
+            assigned_max = min(len(unique_metrics), i * keys_per_processor)
+        assigned_min = (i - 1) * keys_per_processor
         assigned_keys = range(assigned_min, assigned_max)
 
         # Compile assigned metrics


### PR DESCRIPTION
The existing formula for computing the fraction of the metrics to
process for each worker subprocess could result in situations where the
jobs of the last worker overlapped with the ones of the previous worker
or even worse, resulted in an index exception. This commit corrects this
issue.

To visualize the existing issue: With the existing calculations, having
11 metrics and 5 workers resulted in the following provisioning
scheme:

```
1: [0, 1, 2]
2: [3, 4, 5]
3: [6, 7, 8]
4: [9, 10, 11]
5: [8, 9, 10]
```

Worker 4 creates an index error and worker 5 overlaps.
