### PR TITLE
Allow callables as alert targets in the config

### DIFF
--- a/src/analyzer/alerters.py
+++ b/src/analyzer/alerters.py
@@ -65,9 +65,13 @@ def alert_hipchat(alert, metric):
 
 def trigger_alert(alert, metric):
 
-    if '@' in alert[1]:
-        strategy = 'alert_smtp'
+    target = None
+    if callable(alert[1]):
+        target = alert[1]
     else:
-        strategy = 'alert_' + alert[1]
-
-    getattr(alerters, strategy)(alert, metric)
+        if '@' in alert[1]:
+            strategy = 'alert_smtp'
+        else:
+            strategy = 'alert_' + alert[1]
+        target = getattr(alerters, strategy)
+    target(alert, metric)


### PR DESCRIPTION
Enables users to specify any python callable as the second argument for
alerts in the configuration file. As a consequence, adding custom alert
functions is now a configuration property and not a code change anymore.
