### PR TITLE
Correctly handle disconnecting clients

### DIFF
--- a/src/horizon/listen.py
+++ b/src/horizon/listen.py
@@ -110,6 +110,8 @@ class Listen(Process):
         data = ''
         while n > 0:
             buf = sock.recv(n)
+            if len(buf) == 0:
+                raise RuntimeError('Client disconnected')
             n -= len(buf)
             data += buf
         return data


### PR DESCRIPTION
Receiving 0 bytes from a socket means that the client has closed the
connection. Handle this correctly by accepting a new client instead of
continuing to read 0 bytes.
