### PR TITLE
multiple_skylines_graphite_namespace

### DIFF
--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -19,6 +19,10 @@ from algorithm_exceptions import *
 
 logger = logging.getLogger("AnalyzerLog")
 
+try:
+  SERVER_METRIC_PATH = settings.SERVER_METRICS_NAME + '.'
+except:
+  SERVER_METRIC_PATH = ''
 
 class Analyzer(Thread):
     def __init__(self, parent_pid):
@@ -219,8 +223,8 @@ class Analyzer(Thread):
             logger.info('anomaly breakdown :: %s' % anomaly_breakdown)
 
             # Log to Graphite
-            self.send_graphite_metric('skyline.analyzer.run_time', '%.2f' % (time() - now))
-            self.send_graphite_metric('skyline.analyzer.total_analyzed', '%.2f' % (len(unique_metrics) - sum(exceptions.values())))
+            self.send_graphite_metric('skyline.analyzer.' + SERVER_METRIC_PATH + 'run_time', '%.2f' % (time() - now))
+            self.send_graphite_metric('skyline.analyzer.' + SERVER_METRIC_PATH + 'total_analyzed', '%.2f' % (len(unique_metrics) - sum(exceptions.values())))
 
             # Check canary metric
             raw_series = self.redis_conn.get(settings.FULL_NAMESPACE + settings.CANARY_METRIC)
@@ -232,8 +236,8 @@ class Analyzer(Thread):
                 projected = 24 * (time() - now) / time_human
 
                 logger.info('canary duration   :: %.2f' % time_human)
-                self.send_graphite_metric('skyline.analyzer.duration', '%.2f' % time_human)
-                self.send_graphite_metric('skyline.analyzer.projected', '%.2f' % projected)
+                self.send_graphite_metric('skyline.analyzer.' + SERVER_METRIC_PATH + 'duration', '%.2f' % time_human)
+                self.send_graphite_metric('skyline.analyzer.' + SERVER_METRIC_PATH + 'projected', '%.2f' % projected)
 
             # Reset counters
             self.anomalous_metrics[:] = []

--- a/src/horizon/worker.py
+++ b/src/horizon/worker.py
@@ -11,6 +11,10 @@ import settings
 
 logger = logging.getLogger("HorizonLog")
 
+try:
+  SERVER_METRIC_PATH = settings.SERVER_METRICS_NAME + '.'
+except:
+  SERVER_METRIC_PATH = ''
 
 class Worker(Process):
     """
@@ -111,7 +115,7 @@ class Worker(Process):
                 # Log progress
                 if self.canary:
                     logger.info('queue size at %d' % self.q.qsize())
-                    self.send_graphite_metric('skyline.horizon.queue_size', self.q.qsize())
+                    self.send_graphite_metric('skyline.horizon.' + SERVER_METRIC_PATH + 'queue_size', self.q.qsize())
 
             except Empty:
                 logger.info('worker queue is empty and timed out')

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -47,6 +47,13 @@ CARBON_PORT = 2003
 # will occur when Oculus support is disabled.
 OCULUS_HOST = 'http://your_oculus_host.com'
 
+# This is to allow for multiple skyline nodes to send metrics to a graphite
+# instance on the skyline namespace sharded by this setting, like carbon.relays.
+# If you want multiple skyline hosts, set the hostname of the skyline here e.g.
+# skyline.analyzer.run_time
+# skyline.analyzer.skyline-01.run_time
+SERVER_METRICS_NAME = ''
+
 """
 Analyzer settings
 """


### PR DESCRIPTION
Added the ability to allow for multiple skyline nodes to use the skyline
graphite namespace sharded by hostname like carbon.relays.
Modified:
src/settings.py.example
src/analyzer/analyzer.py
src/horizon/worker.py
