### PR TITLE
Break the loop when connection closes.

### DIFF
--- a/src/horizon/listen.py
+++ b/src/horizon/listen.py
@@ -46,9 +46,14 @@ class Listen(Process):
         """
         data = ''
         while n > 0:
-            buf = sock.recv(n)
-            n -= len(buf)
-            data += buf
+            chunk = sock.recv(n)
+            count = len(chunk)
+
+            if count == 0:
+                break
+
+            n -= count
+            data += chunk
         return data
 
     def check_if_parent_is_alive(self):


### PR DESCRIPTION
At the moment when f.ex. carbon-relay will be restarted
on the other side listener will end up in infinite loop
reading 0 bytes all the time.

When a recv returns 0 bytes, it means the other side has closed
(or is in the process of closing) the connection -
https://docs.python.org/2/howto/sockets.html